### PR TITLE
Broken link to Equally Likely Events under Serendipity

### DIFF
--- a/en/examples/serendipity/index.html
+++ b/en/examples/serendipity/index.html
@@ -417,7 +417,7 @@
 					  	<hr/>
 					  	<h3>Approach</h3>
 					  	<p>
-					  		Since each way of seeing $s$ people is equally likely, we can use the "<a href="//web.stanford.edu/class/cs109/pdfs/HO06 Probability.pdf">Equally Likely Events</a>" probability calculation: 
+					  		Since each way of seeing $s$ people is equally likely, we can use the <li><a href="#equally_likely/">Equally Likely</a></li> probability calculation: 
 					  	</p>
 
 					  	<p style="font-size:120%">


### PR DESCRIPTION
After calculating an example of the serendipity problem, the link to the "Equally Likely Events" takes me to a 404 under stanford.edu instead of to the direct portion of the reader (where I assume it's supposed to go)

Tried to update the link but not sure if I did it right!